### PR TITLE
fix: send `updateCart` event to parent window when app is loaded as iframe content

### DIFF
--- a/@typing/global.d.ts
+++ b/@typing/global.d.ts
@@ -1,0 +1,15 @@
+import { IFrameObject as IframeResizerObject } from "iframe-resizer"
+
+type IframeMessagePayload = {
+  type: "updateCart"
+}
+
+type IFrameObject = Omit<IframeResizerObject, "sendMessage"> & {
+  sendMessage: (message: IframeMessagePayload, targetOrigin: string) => void
+}
+
+export declare global {
+  interface Window {
+    parentIFrame?: IFrameObject
+  }
+}

--- a/components/Cart/index.tsx
+++ b/components/Cart/index.tsx
@@ -32,6 +32,15 @@ const Cart: FC = () => {
         attributes={{
           cart_url: settings.cartUrl || window.location.href,
         }}
+        fetchOrder={() => {
+          if ("parentIFrame" in window) {
+            // send update event to parent iframe if iframe-resizer is enabled
+            const parentIFrame = (window as any).parentIFrame
+            parentIFrame &&
+              parentIFrame.sendMessage &&
+              parentIFrame.sendMessage("cartUpdate", "*")
+          }
+        }}
       >
         <LineItemsContainer>
           <PageLayout

--- a/components/Cart/index.tsx
+++ b/components/Cart/index.tsx
@@ -33,13 +33,8 @@ const Cart: FC = () => {
           cart_url: settings.cartUrl || window.location.href,
         }}
         fetchOrder={() => {
-          if ("parentIFrame" in window) {
-            // send update event to parent iframe if iframe-resizer is enabled
-            const parentIFrame = (window as any).parentIFrame
-            parentIFrame &&
-              parentIFrame.sendMessage &&
-              parentIFrame.sendMessage("cartUpdate", "*")
-          }
+          // send update event to parent iframe if iframe-resizer is enabled
+          window.parentIFrame?.sendMessage({ type: "updateCart" }, "*")
         }}
       >
         <LineItemsContainer>

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@next/eslint-plugin-next": "^12.1.6",
     "@playwright/test": "^1.22.2",
     "@types/async-retry": "^1.4.4",
+    "@types/iframe-resizer": "^3.5.9",
     "@types/jest": "^27.5.1",
     "@types/node": "17.0.31",
     "@types/react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,6 +1413,11 @@
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
 
+"@types/iframe-resizer@^3.5.9":
+  version "3.5.9"
+  resolved "https://registry.yarnpkg.com/@types/iframe-resizer/-/iframe-resizer-3.5.9.tgz#75c4cda33cee5f4da4c7693a0d9ad1ccb0c5ee98"
+  integrity sha512-RQUBI75F+uXruB95BFpC/8V8lPgJg4MQ6HxOCtAZYBB/h0FNCfrFfb4I+u2pZJIV7sKeszZbFqy1UnGeBMrvsA==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz"


### PR DESCRIPTION
### What does this PR do?
When the cart is loaded as an `<iframe>`, we will dispatch an event to the parent window every time the order is updated.
To do so we leverage the `iframe-resizer` library to post a message from the iframe content to the iframe parent.

- [iframe-resizer documentation](https://github.com/davidjbradshaw/iframe-resizer)
-  [window.postMessage API on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage)

Message payload is:
```
{ type: "updateCart" }
```

Note: at this stage, we are unable to whitelist or filter by `targetOrigin`, we might be able to apply a solution for this in another release