### PR TITLE
fix: send `close` and `blur` events to parent window when cart is embedded

### DIFF
--- a/@typing/global.d.ts
+++ b/@typing/global.d.ts
@@ -1,7 +1,9 @@
 import { IFrameObject as IframeResizerObject } from "iframe-resizer"
 
+type IframeEvent = "updateCart" | "close" | "blur"
+
 type IframeMessagePayload = {
-  type: "updateCart"
+  type: IframeEvent
 }
 
 type IFrameObject = Omit<IframeResizerObject, "sendMessage"> & {

--- a/components/Cart/index.tsx
+++ b/components/Cart/index.tsx
@@ -13,10 +13,12 @@ import { Summary } from "#components/Cart/Summary"
 import { PageHeader } from "#components/PageHeader"
 import { PageLayout } from "#components/PageLayout"
 import { useSettings } from "#components/SettingsProvider"
+import { useSendEmbeddedEvents } from "hooks/embedded"
 
 const Cart: FC = () => {
   const { settings } = useSettings()
   const { t } = useTranslation()
+  useSendEmbeddedEvents()
 
   if (!settings || !settings.isValid) {
     return null

--- a/hooks/embedded.ts
+++ b/hooks/embedded.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react"
+
+import { isEmbedded } from "#utils/isEmbedded"
+
+function sendEventClose(e: KeyboardEvent) {
+  if (e.key === "Escape") {
+    window.parentIFrame?.sendMessage({ type: "close" }, "*")
+  }
+}
+
+function sendEventBlur() {
+  window.parentIFrame?.sendMessage({ type: "blur" }, "*")
+}
+
+export function useSendEmbeddedEvents() {
+  const embedded = isEmbedded()
+
+  useEffect(() => {
+    if (!embedded) {
+      return
+    }
+
+    window.addEventListener("keydown", sendEventClose)
+    window.addEventListener("blur", sendEventBlur)
+    return () => {
+      window.removeEventListener("keydown", sendEventClose)
+      window.removeEventListener("blur", sendEventBlur)
+    }
+  }, [embedded])
+  return null
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commercelayer-cart",
   "version": "1.0.13",
-  "private": false,
+  "private": true,
   "author": {
     "name": "Giuseppe Ciotola",
     "email": "giuseppe@commercelayer.io"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,9 +2249,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001335:
-  version "1.0.30001338"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz"
-  integrity sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==
+  version "1.0.30001431"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz"
+  integrity sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==
 
 card-validator@8.1.1:
   version "8.1.1"


### PR DESCRIPTION
### What does this PR do?
When cart is embedded as `<iframe>`, we need to forward more events to its parent window.
In detail this PR implements the following new events:
- `close` when escape key is pressed
- `blur` when focus on content window is lost
