### PR TITLE
feat: add new iframe event to trigger refresh order hook

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,7 +54,10 @@
       "error",
       {
         "ignore": [
-          "HostedApp"
+          "HostedApp",
+          // waiting for fix from: https://github.com/import-js/eslint-plugin-import/issues/1810
+          // and be able to resolve package.json export paths
+          "@commercelayer/react-components/"
         ]
       }
     ],

--- a/@typing/global.d.ts
+++ b/@typing/global.d.ts
@@ -1,6 +1,7 @@
 import { IFrameObject as IframeResizerObject } from "iframe-resizer"
 
 type IframeEvent = "updateCart" | "close" | "blur"
+type IframeReceivedEvent = "updateCart"
 
 type IframeMessagePayload = {
   type: IframeEvent
@@ -15,5 +16,9 @@ export declare global {
 
   interface Window {
     parentIFrame?: IFrameObject
+    iFrameResizer?: {
+      onMessage?: (message: { type?: IframeReceivedEvent }) => void
+    }
+    reloadOrderCallback?: () => void
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@commercelayer/js-auth": "^2.3.0",
-    "@commercelayer/react-components": "4.0.1",
+    "@commercelayer/react-components": "4.1.0-beta.1",
     "@commercelayer/react-utils": "1.0.0-beta.3",
     "@commercelayer/sdk": "^4.15.0",
     "@playwright/test": "^1.22.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ overrides:
 
 specifiers:
   '@commercelayer/js-auth': ^2.3.0
-  '@commercelayer/react-components': 4.0.1
+  '@commercelayer/react-components': 4.1.0-beta.1
   '@commercelayer/react-utils': 1.0.0-beta.3
   '@commercelayer/sdk': ^4.15.0
   '@playwright/test': ^1.22.2
@@ -52,7 +52,7 @@ specifiers:
 
 dependencies:
   '@commercelayer/js-auth': 2.3.0
-  '@commercelayer/react-components': 4.0.1_biqbaboplfbrettd7655fr4n2y
+  '@commercelayer/react-components': 4.1.0-beta.1_biqbaboplfbrettd7655fr4n2y
   '@commercelayer/react-utils': 1.0.0-beta.3_bo4vbfjw665tadamc2m57ahjv4
   '@commercelayer/sdk': 4.15.0
   '@playwright/test': 1.22.2
@@ -474,8 +474,8 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@commercelayer/react-components/4.0.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-MJTiWyetzOCmGn6DVfUlZ6I9sUZAvWDfJYRBXRpzlJPWkblDwlkAR7ZdwRs7iysqxtGRI+8Kn54q5qGKk51h5w==}
+  /@commercelayer/react-components/4.1.0-beta.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-AXRjpNusabVUxLsyAoFt76wS26Osp0BW83QnL4MIpHpMINDrIIz9ZPzKeRxC4wlo/I8DvpFGHwkcqIt7psBEJg==}
     peerDependencies:
       react: ^18.0.0
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,15 @@
-import { Helmet, HelmetProvider } from "react-helmet-async"
+import { HelmetProvider } from "react-helmet-async"
 import { Router, Route, Switch } from "wouter"
 
 import CartPage from "./pages/CartPage"
 import ErrorPage from "./pages/ErrorPage"
 
-import { isEmbedded } from "#utils/isEmbedded"
+import { EmbeddedCapabilities } from "#components/EmbeddedCapabilities"
 
 function App(): JSX.Element {
   return (
     <HelmetProvider>
-      <Helmet>
-        {isEmbedded() && (
-          <script
-            src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.js"
-            data-test-id="iframe-resizer-script"
-            type="text/javascript"
-          />
-        )}
-      </Helmet>
+      <EmbeddedCapabilities.IframeResizerInit />
       <Router base={import.meta.env.PUBLIC_BASE_PATH}>
         <Switch>
           <Route path={"/404"}>

--- a/src/components/Cart/index.tsx
+++ b/src/components/Cart/index.tsx
@@ -10,15 +10,14 @@ import { useTranslation } from "react-i18next"
 import { Totals } from "./Totals"
 
 import { Summary } from "#components/Cart/Summary"
+import { EmbeddedCapabilities } from "#components/EmbeddedCapabilities"
 import { PageHeader } from "#components/PageHeader"
 import { PageLayout } from "#components/PageLayout"
 import { useSettings } from "#components/SettingsProvider"
-import { useSendEmbeddedEvents } from "#hooks/embedded"
 
 const Cart: FC = () => {
   const { settings } = useSettings()
   const { t } = useTranslation()
-  useSendEmbeddedEvents()
 
   if (!settings || !settings.isValid) {
     return null
@@ -39,6 +38,7 @@ const Cart: FC = () => {
           window.parentIFrame?.sendMessage({ type: "updateCart" }, "*")
         }}
       >
+        <EmbeddedCapabilities.OrderRefresher />
         <LineItemsContainer>
           <PageLayout
             top={

--- a/src/components/EmbeddedCapabilities.tsx
+++ b/src/components/EmbeddedCapabilities.tsx
@@ -1,0 +1,77 @@
+import useOrderContainer from "@commercelayer/react-components/hooks/useOrderContainer"
+import { FC, useEffect, useLayoutEffect } from "react"
+import { Helmet } from "react-helmet-async"
+
+import { isEmbedded } from "#utils/isEmbedded"
+
+function sendEventClose(e: KeyboardEvent) {
+  if (e.key === "Escape") {
+    window.parentIFrame?.sendMessage({ type: "close" }, "*")
+  }
+}
+
+function sendEventBlur() {
+  window.parentIFrame?.sendMessage({ type: "blur" }, "*")
+}
+
+const IframeResizerInit: FC = () => {
+  const embedded = isEmbedded()
+
+  useEffect(() => {
+    if (!embedded) {
+      return
+    }
+
+    window.addEventListener("keydown", sendEventClose)
+    window.addEventListener("blur", sendEventBlur)
+    return () => {
+      window.removeEventListener("keydown", sendEventClose)
+      window.removeEventListener("blur", sendEventBlur)
+    }
+  }, [embedded])
+
+  useLayoutEffect(() => {
+    if (!embedded) {
+      return
+    }
+
+    window.iFrameResizer = {
+      onMessage: ({ type }) => {
+        if (type === "updateCart") {
+          window.reloadOrderCallback && window.reloadOrderCallback()
+        }
+      },
+    }
+  }, [embedded])
+
+  return (
+    <>
+      <Helmet>
+        {isEmbedded() && (
+          <script
+            src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.js"
+            data-test-id="iframe-resizer-script"
+            type="text/javascript"
+          />
+        )}
+      </Helmet>
+    </>
+  )
+}
+
+const OrderRefresher: FC = () => {
+  const { order, reloadOrder } = useOrderContainer()
+
+  useLayoutEffect(() => {
+    window.reloadOrderCallback = () => {
+      reloadOrder()
+    }
+  }, [order])
+
+  return null
+}
+
+export const EmbeddedCapabilities = {
+  IframeResizerInit,
+  OrderRefresher,
+}

--- a/src/components/EmbeddedCapabilities.tsx
+++ b/src/components/EmbeddedCapabilities.tsx
@@ -17,48 +17,58 @@ function sendEventBlur() {
 const IframeResizerInit: FC = () => {
   const embedded = isEmbedded()
 
-  useEffect(() => {
-    if (!embedded) {
-      return
-    }
+  useEffect(
+    function setEventListeners() {
+      if (!embedded) {
+        return
+      }
 
-    window.addEventListener("keydown", sendEventClose)
-    window.addEventListener("blur", sendEventBlur)
-    return () => {
-      window.removeEventListener("keydown", sendEventClose)
-      window.removeEventListener("blur", sendEventBlur)
-    }
-  }, [embedded])
+      window.addEventListener("keydown", sendEventClose)
+      window.addEventListener("blur", sendEventBlur)
+      return () => {
+        window.removeEventListener("keydown", sendEventClose)
+        window.removeEventListener("blur", sendEventBlur)
+      }
+    },
+    [embedded]
+  )
 
-  useLayoutEffect(() => {
-    if (!embedded) {
-      return
-    }
+  useLayoutEffect(
+    function initIFrameResizerSettings() {
+      if (!embedded) {
+        return
+      }
 
-    window.iFrameResizer = {
-      onMessage: ({ type }) => {
-        if (type === "updateCart") {
-          window.reloadOrderCallback && window.reloadOrderCallback()
-        }
-      },
-    }
-  }, [embedded])
+      window.iFrameResizer = {
+        onMessage: ({ type }) => {
+          if (type === "updateCart") {
+            // `reloadOrderCallback` will be create insider `<OrderRefresher>` component
+            // since we need to access order context that will be available later
+            window.reloadOrderCallback && window.reloadOrderCallback()
+          }
+        },
+      }
+    },
+    [embedded]
+  )
+
+  if (!embedded) {
+    return null
+  }
 
   return (
-    <>
-      <Helmet>
-        {isEmbedded() && (
-          <script
-            src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.js"
-            data-test-id="iframe-resizer-script"
-            type="text/javascript"
-          />
-        )}
-      </Helmet>
-    </>
+    <Helmet>
+      <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.js"
+        data-test-id="iframe-resizer-script"
+        type="text/javascript"
+      />
+    </Helmet>
   )
 }
 
+// This component is only responsible to inject in globalWindow the `reloadOrderCallback` function
+// that will be used in the `onMessage` method initialized from iFrameResizer
 const OrderRefresher: FC = () => {
   const { order, reloadOrder } = useOrderContainer()
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,24 @@ export default defineConfig(({ mode }) => {
     build: {
       target: "esnext",
       outDir: "build",
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            vendor: [
+              "react",
+              "react-dom",
+              "react-helmet-async",
+              "wouter",
+              "react-gtm-module",
+              "react-i18next",
+            ],
+            commercelayer: [
+              "@commercelayer/sdk",
+              "@commercelayer/react-components",
+            ],
+          },
+        },
+      },
     },
     resolve: {
       alias: {


### PR DESCRIPTION
### What does this PR do?
When hosted-cart is embedded and loaded as an iframe, we not only need to send events to the parent window, but also be able to listen for events received.

This PR adds a listener for the `updateCart` event that will trigger the new `reloadOrder()` hook exposed from `@commercelayer/react-components` 

Also, a bit of code refactoring has been required to keep all iframe/embeddable capability in one component and iframe-related code altogether.

