### PR TITLE
Fix: disable quantity selector UI when quantity is updating

### DIFF
--- a/src/components/atoms/InputSpinner.module.css
+++ b/src/components/atoms/InputSpinner.module.css
@@ -4,4 +4,5 @@
   -webkit-appearance: none;
   margin: 0;
   -moz-appearance: textfield !important;
+  border-radius: 0; /* prevent safari to display native status when appearance is none */
 }

--- a/src/components/atoms/InputSpinner.tsx
+++ b/src/components/atoms/InputSpinner.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import css from "./InputSpinner.module.css"
 
 import { useDebounce } from "#hooks/debounce"
-import { useCheckFirstMount } from "#hooks/mount"
 
 interface Props {
   /*
@@ -36,8 +35,8 @@ export function InputSpinner({
   const [internalDisabled, setInternalDisabled] = useState(disabled)
   const { debouncedValue } = useDebounce(internalValue, debounceMs)
   const inputEl = useRef<HTMLInputElement | null>(null)
-  const { isFirstMount } = useCheckFirstMount()
   const isDisabled = disabled || internalDisabled
+  const isInternalValueSynched = quantity === internalValue
 
   const handleButtonClick = useCallback((action: "increment" | "decrement") => {
     setInternalValue((state) => {
@@ -48,7 +47,7 @@ export function InputSpinner({
 
   useEffect(
     function dispatchDebouncedHandleChange() {
-      if (isFirstMount) {
+      if (isInternalValueSynched) {
         return
       }
       const event = makeSyntheticChangeEvent({
@@ -67,7 +66,7 @@ export function InputSpinner({
   useEffect(
     function syncInternalStateWithOrderQuantity() {
       setInternalDisabled(false)
-      if (internalValue !== quantity) {
+      if (!isInternalValueSynched) {
         setInternalValue(quantity)
       }
     },

--- a/src/components/atoms/InputSpinner.tsx
+++ b/src/components/atoms/InputSpinner.tsx
@@ -37,6 +37,7 @@ export function InputSpinner({
   const { debouncedValue } = useDebounce(internalValue, debounceMs)
   const inputEl = useRef<HTMLInputElement | null>(null)
   const { isFirstMount } = useCheckFirstMount()
+  const isDisabled = disabled || internalDisabled
 
   const handleButtonClick = useCallback((action: "increment" | "decrement") => {
     setInternalValue((state) => {
@@ -73,11 +74,23 @@ export function InputSpinner({
     [quantity]
   )
 
+  useEffect(
+    function preventOutOfStockToPermanentlyDisableUi() {
+      if (internalDisabled) {
+        setTimeout(() => {
+          // when out of stock, we won't receive a new `quantity`
+          setInternalDisabled(false)
+        }, debounceMs + 10)
+      }
+    },
+    [internalDisabled]
+  )
+
   return (
     <div
       {...rest}
       className={cn("inline-flex  rounded overflow-hidden", css.inputSpinner, {
-        "opacity-50 pointer-events-none": internalDisabled,
+        "opacity-50 pointer-events-none": isDisabled,
       })}
     >
       <button
@@ -86,7 +99,7 @@ export function InputSpinner({
         onClick={() => {
           handleButtonClick("decrement")
         }}
-        disabled={internalDisabled}
+        disabled={isDisabled}
       >
         -
       </button>
@@ -104,7 +117,7 @@ export function InputSpinner({
             setInternalValue(value)
           }
         }}
-        disabled={internalDisabled}
+        disabled={isDisabled}
       />
       <button
         data-test-id="input-spinner-btn-increment"
@@ -112,7 +125,7 @@ export function InputSpinner({
         onClick={() => {
           handleButtonClick("increment")
         }}
-        disabled={internalDisabled}
+        disabled={isDisabled}
       >
         +
       </button>


### PR DESCRIPTION
### What does this PR do?

- [x] disable input spinner UI when order is updating
- [x] replace `isFirstMount` logic with `isInternalValueSynched` flag 
