### PR TITLE
Remove sending of close event on minicart

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.1",
+  "version": "3.1.2-stg.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",

--- a/packages/cart/package.json
+++ b/packages/cart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercelayer-cart",
-  "version": "3.1.1",
+  "version": "3.1.2-stg.0",
   "private": true,
   "author": {
     "name": "Giuseppe Ciotola",

--- a/packages/cart/src/components/Cart/Summary/index.tsx
+++ b/packages/cart/src/components/Cart/Summary/index.tsx
@@ -26,18 +26,6 @@ export const Summary: FC<Props> = ({ listTypes }) => {
   const { t } = useTranslation()
   const { settings } = useSettings()
 
-  const hasReturnUrl =
-    settings.isValid &&
-    settings.returnUrl &&
-    settings.returnUrl !== window.parent.location.href // no need to show return url is the same as current url
-
-  // allow to send close message to parent window when embedded in same page of returnUrl
-  const isEmbeddedMiniCart =
-    isEmbedded() &&
-    settings.isValid &&
-    settings.returnUrl === window.parent.location.href &&
-    window.parent.location.href !== window.location.href
-
   return (
     <>
       {listTypes.map((type) => (
@@ -93,27 +81,18 @@ export const Summary: FC<Props> = ({ listTypes }) => {
       </LineItemsEmpty>
 
       {/* Return Url */}
-      <div className="pt-2 pb-8">
-        {hasReturnUrl ? (
+      {settings.isValid && settings.returnUrl ? (
+        <div className="pt-2 pb-8">
           <a
             data-test-id="return-url"
             href={settings.returnUrl}
             className="link-base text-xs font-bold"
-            target={isEmbedded() ? "_top" : undefined} // if embedded, open in parent window
+            target={isEmbedded() ? "_top" : undefined}
           >
             &lt; {t("general.returnUrlLabel")}
           </a>
-        ) : isEmbeddedMiniCart ? (
-          <button
-            className="link-base text-xs font-bold"
-            onClick={() => {
-              window.parentIFrame?.sendMessage({ type: "close" }, "*")
-            }}
-          >
-            &lt; {t("general.returnUrlLabel")}
-          </button>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
     </>
   )
 }


### PR DESCRIPTION
This reverts changes applied from https://github.com/commercelayer/commercelayer-cart/pull/40 since we decided it is not necessary to keep this logic inside the cart application.